### PR TITLE
deleted: width of heading and title on media 768px

### DIFF
--- a/static/css/media.css
+++ b/static/css/media.css
@@ -56,7 +56,6 @@
     }
 
     .heading .title {
-        width: 30%;
         vertical-align: middle;
     }
 


### PR DESCRIPTION
1. I have deleted the width for the heading and the title on media query 768 pixels